### PR TITLE
Fix: sensitive config fields being shown decrypted in plain text

### DIFF
--- a/templates/stream_detail.html
+++ b/templates/stream_detail.html
@@ -218,7 +218,7 @@
                 </h5>
             </div>
             <div class="card-body">
-                {% set config = stream.get_plugin_config() %}
+                {% set config = stream.to_dict(include_sensitive=False).get('plugin_config', {}) %}
                 {% if config %}
                     <div class="row">
                         {% for key, value in config.items() %}
@@ -226,11 +226,7 @@
                             <div class="info-group">
                                 <label class="info-label">{{ key|title|replace('_', ' ') }}</label>
                                 <div class="info-value">
-                                    {% if key in ['password', 'feed_password'] %}
-                                        <span class="text-mono text-muted">••••••••</span>
-                                    {% else %}
-                                        <span class="text-mono">{{ value }}</span>
-                                    {% endif %}
+                                    <span class="text-mono">{{ value }}</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Issue
When a sensitive config field is outside of the hard-coded names "password" and "feed_password" they are shown as plain text in a decrypted state.
The existing check is not scalable as the field could be named "API Key", etc.

### Fix
Rely on the application's internal mechanisms for handling sensitive config to fetch the plugin config